### PR TITLE
Fix crash on Mac due to PInvoke issue.

### DIFF
--- a/src/go/bindings/bindings.c
+++ b/src/go/bindings/bindings.c
@@ -1,11 +1,11 @@
 ﻿#include "bindings.h"
 
-int Read(Snapshot snapshot, uint8_t buffer[], int offset, int count)
+int32_t Read(Snapshot snapshot, uint8_t buffer[], int32_t offset, int32_t count)
 {
     return snapshot.ReadChar(buffer, offset, count);
 }
 
-void InvokeStringCallback(ProvideStringCallback callback, uint8_t buffer[], int count)
+void InvokeStringCallback(ProvideStringCallback callback, uint8_t buffer[], int32_t count)
 {
     callback(buffer, count);
 }

--- a/src/go/bindings/bindings.go
+++ b/src/go/bindings/bindings.go
@@ -32,12 +32,12 @@ func (reader *snapshotReader) Read(buffer []byte) (n int, err error) {
 }
 
 //export CreateNewWorkspace
-func CreateNewWorkspace() int {
-	return int(languageservice.CreateNewWorkspace())
+func CreateNewWorkspace() int32 {
+	return int32(languageservice.CreateNewWorkspace())
 }
 
 //export RegisterWorkspaceUpdateCallback
-func RegisterWorkspaceUpdateCallback(workspaceID int, callback C.ProvideStringCallback) {
+func RegisterWorkspaceUpdateCallback(workspaceID int32, callback C.ProvideStringCallback) {
 
 	goCallback := func(fileName string) {
 		fileNameSlice := []byte(fileName)
@@ -48,25 +48,25 @@ func RegisterWorkspaceUpdateCallback(workspaceID int, callback C.ProvideStringCa
 }
 
 //export QueueFileParse
-func QueueFileParse(workspaceID int, fileName *byte, count int, snapshot C.Snapshot) {
+func QueueFileParse(workspaceID int32, fileName *byte, count int32, snapshot C.Snapshot) {
 	reader := snapshot.newReader()
 	fileNameString := cToString(fileName, count)
 	languageservice.WorkspaceID(workspaceID).QueueFileParse(fileNameString, reader)
 }
 
 //export GetWorkspaceErrors
-func GetWorkspaceErrors(workspaceID int, callback C.ProvideStringCallback) {
+func GetWorkspaceErrors(workspaceID int32, callback C.ProvideStringCallback) {
 	rawErrors := languageservice.WorkspaceID(workspaceID).GetWorkspaceErrors()
 
 	for _, err := range rawErrors {
 
-        errorText := []byte(err.Error())
+		errorText := []byte(err.Error())
 
-        C.InvokeStringCallback(callback, (*C.uint8_t)(&errorText[0]), C.int(len(errorText)))
+		C.InvokeStringCallback(callback, (*C.uint8_t)(&errorText[0]), C.int(len(errorText)))
 	}
 }
 
-func cToString(bytes *byte, length int) string {
+func cToString(bytes *byte, length int32) string {
 	// TODO: there are 2 copies being made here. Eliminate one.
 	return string(C.GoBytes(unsafe.Pointer(bytes), C.int(length)))
 }

--- a/src/go/bindings/bindings.h
+++ b/src/go/bindings/bindings.h
@@ -16,18 +16,18 @@
 
 typedef struct tagSnapshot
 {
-    int (*ReadChar)(uint8_t buffer[], int offset, int count);
-    int length;
+    int32_t (*ReadChar)(uint8_t*, int32_t, int32_t);
+    int32_t length;
 } Snapshot;
 
 // Go can't execute C function pointers, so we have this monstrosity.
-int Read(Snapshot snapshot, uint8_t buffer[], int offset, int count);
+int32_t Read(Snapshot snapshot, uint8_t buffer[], int32_t offset, int32_t count);
 
 // .. and this one too
-typedef void (*ProvideStringCallback)(uint8_t buffer[], int count);
+typedef void (*ProvideStringCallback)(uint8_t buffer[], int32_t count);
 
 // .. and this one too.
-void InvokeStringCallback(ProvideStringCallback callback, uint8_t buffer[], int count);
+void InvokeStringCallback(ProvideStringCallback callback, uint8_t buffer[], int32_t count);
 
 
 #endif


### PR DESCRIPTION
Not sure the origin of the problem but annotating byte* with [Out] on a function pointer leads to a crash on MacOS.